### PR TITLE
Fix Issue #4. Change the behavior of `Combinator.Lazy`

### DIFF
--- a/Parseq.Test/CombinatorTest.cs
+++ b/Parseq.Test/CombinatorTest.cs
@@ -76,6 +76,12 @@ namespace Parseq.Test
             Combinator.Choice(failure, error).ExpectError().Run("foobar".AsStream());
             Combinator.Choice(success, error).ExpectSuccess().Run("foobar".AsStream());
             Combinator.Choice(error, success).ExpectError().Run("foobar".AsStream());
+
+            // Issue #4 
+            // Combinator.Choice does not work since second time parsing in Parseq 
+            var parser = Combinator.Choice(new[] { 'a', 'b', 'c' }.Select(_ => _.Satisfy()));
+            parser.ExpectSuccess('c').Run("c".AsStream());
+            parser.ExpectSuccess('c').Run("c".AsStream());        
         }
 
         [TestMethod]

--- a/Parseq/Combinator.cs
+++ b/Parseq/Combinator.cs
@@ -247,12 +247,19 @@ namespace Parseq
         }
 
         public static Parser<TToken, TResult> Lazy<TToken, TResult>(
-            this Func<Parser<TToken, TResult>> parser)
+            this Func<Parser<TToken, TResult>> func)
         {
-            if (parser == null)
+            if (func == null)
                 throw new ArgumentNullException("parser");
 
-            return stream => parser()(stream);
+            var cache = Option.None<Parser<TToken, TResult>>();
+            return stream =>
+            {
+                Parser<TToken, TResult> result;
+                if (!cache.TryGetValue(out result))
+                    cache = (result = func());
+                return result.Run(stream);
+            };
         }
 
         public static Parser<TToken, Unit> Ignore<TToken, TResult>(


### PR DESCRIPTION
add Cache System to Combinator.Lazy. This resulted in to prevent
instantiation multiple times.
