### PR TITLE
Fix InvalidCastException bugs in TryGet- methods

### DIFF
--- a/Parseq/Either.cs
+++ b/Parseq/Either.cs
@@ -35,8 +35,8 @@ namespace Parseq
 
     public interface IEither<out TLeft, out TRight>
     {
+        Hand Hand { get; }
         IOption<TLeft> Left { get; }
-        
         IOption<TRight> Right { get; }
     }
 
@@ -44,6 +44,8 @@ namespace Parseq
         : IEither<TLeft, TRight>
         , IEquatable<IEither<TLeft, TRight>>
     {
+        public abstract Hand Hand { get; }
+
         public abstract Hand TryGetValue(out TLeft left, out TRight right);
 
         public virtual Boolean Equals(IEither<TLeft, TRight> other)
@@ -75,6 +77,11 @@ namespace Parseq
                 get { return Option.None<TRight>(); }
             }
 
+            public override Hand Hand
+            {
+                get { return Hand.Left; }
+            }
+
             public override Hand TryGetValue(out TLeft left, out TRight right)
             {
                 left = _left;
@@ -102,6 +109,11 @@ namespace Parseq
             public override IOption<TRight> Right
             {
                 get { return Option.Just(this._right); }
+            }
+
+            public override Hand Hand
+            {
+                get { return Hand.Right; }
             }
 
             public override Hand TryGetValue(out TLeft left, out TRight right)

--- a/Parseq/EitherExtensions.cs
+++ b/Parseq/EitherExtensions.cs
@@ -31,20 +31,45 @@ namespace Parseq
     {
         public static Hand TryGetValue<TLeft, TRight>(this IEither<TLeft, TRight> self, out TLeft left, out TRight right)
         {
-            // TODO: Assumed that self is Either<TLeft, TRight> implicitly
-            return ((Either<TLeft, TRight>)self).TryGetValue(out left, out right);
+            switch (self.Hand)
+            {
+                case Hand.Left:
+                    left = self.Left.Value;
+                    right = default(TRight);
+                    return Hand.Left;
+                default: // case Hand.Right:
+                    left = default(TLeft);
+                    right = self.Right.Value;
+                    return Hand.Right;
+            }
         }
 
         public static Boolean TryGetLeft<TLeft, TRight>(this IEither<TLeft, TRight> self, out TLeft value)
         {
-            // TODO: Assumed that self is Either<TLeft, TRight> implicitly
-            return ((Either<TLeft, TRight>)self).TryGetLeft(out value);
+            switch (self.Hand)
+            {
+                case Hand.Left:
+                    value = self.Left.Value;
+                    return true;
+                default: // case Hand.Right:
+                    value = default(TLeft);
+                    return false;
+            }
         }
 
         public static Boolean TryGetRight<TLeft, TRight>(this IEither<TLeft, TRight> self, out TRight value)
         {
-            // TODO: Assumed that self is Either<TLeft, TRight> implicitly
-            return ((Either<TLeft, TRight>)self).TryGetRight(out value);
+            switch (self.Hand)
+            {
+                case Hand.Left:
+                    value = default(TRight);
+                    return false;
+                case Hand.Right:
+                    value = self.Right.Value;
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException("Hand");
+            }
         }
 
         public static T Merge<TLeft, TRight, T>(

--- a/Parseq/Reply.cs
+++ b/Parseq/Reply.cs
@@ -38,6 +38,7 @@ namespace Parseq
         : IEither<IOption<TResult>, ErrorMessage>
     {
         IStream<TToken> Stream { get; }
+        ReplyStatus Status { get; }
     }
 
     public abstract partial class Reply<TToken, TResult>
@@ -45,6 +46,7 @@ namespace Parseq
         , IReply<TToken, TResult>
     {
         public abstract IStream<TToken> Stream { get; }
+        public abstract ReplyStatus Status { get; }
         public abstract ReplyStatus TryGetValue(out TResult result, out ErrorMessage error);
     }
 
@@ -67,6 +69,16 @@ namespace Parseq
             public override IStream<TToken> Stream
             {
                 get { return _stream; }
+            }
+
+            public override ReplyStatus Status
+            {
+                get { return ReplyStatus.Success; }
+            }
+
+            public override Hand Hand
+            {
+                get { return Hand.Left; }
             }
 
             public override Hand TryGetValue(out IOption<TResult> left, out ErrorMessage right)
@@ -99,6 +111,16 @@ namespace Parseq
             public override IStream<TToken> Stream
             {
                 get { return _stream; }
+            }
+
+            public override ReplyStatus Status
+            {
+                get { return ReplyStatus.Failure; }
+            }
+
+            public override Hand Hand
+            {
+                get { return Hand.Left; }
             }
 
             public override Hand TryGetValue(out IOption<TResult> left, out ErrorMessage right)
@@ -135,6 +157,16 @@ namespace Parseq
             public override IStream<TToken> Stream
             {
                 get { return _stream; }
+            }
+
+            public override ReplyStatus Status
+            {
+                get { return ReplyStatus.Error; }
+            }
+
+            public override Hand Hand
+            {
+                get { return Hand.Right; }
             }
 
             public override Hand TryGetValue(out IOption<TResult> left, out ErrorMessage right)

--- a/Parseq/ReplyExtensions.cs
+++ b/Parseq/ReplyExtensions.cs
@@ -31,8 +31,23 @@ namespace Parseq
     {
         public static ReplyStatus TryGetValue<TToken, TResult>(this IReply<TToken, TResult> self, out TResult result, out ErrorMessage error)
         {
-            // TODO: Assumed that self is Reply<TToken, TResult> implicitly
-            return ((Reply<TToken, TResult>)self).TryGetValue(out result, out error);
+            switch (self.Status)
+            {
+                case ReplyStatus.Success:
+                    result = self.Left.Value.Value;
+                    error = null;
+                    return ReplyStatus.Success;
+                case ReplyStatus.Failure:
+                    result = default(TResult);
+                    error = null;
+                    return ReplyStatus.Failure;
+                case ReplyStatus.Error:
+                    result = default(TResult);
+                    error = self.Right.Value;
+                    return ReplyStatus.Error;
+                default:
+                    throw new ArgumentOutOfRangeException("Status");
+            }
         }
 
         public static Boolean TryGetValue<TToken, TResult>(this IReply<TToken, TResult> self, out TResult result)


### PR DESCRIPTION
## 概要
#8 によって生じたバグの修正と、それに伴うプロパティの追加。
## 目的

`TResultDerived : TResult` のとき、 `IReply<TToken, TResultDerived>` を `Reply<TToken, TResult>` のキャストに失敗する (`IReply<TToken, TResultDerived>` にはできる) ので、TryGet- 拡張メソッドで例外が発生する可能性がある。
## 詳細
- TryGet- 拡張メソッドを真面目に実装した。
- 実装において必要なため、`IEither<,>` に `Hand` プロパティを、`IReply<,>` に `Status` プロパティを追加し、それぞれ適切に実装した。
